### PR TITLE
Increase BUFR_TABLEB_UNIT_LENGTH to prevent segfault

### DIFF
--- a/src/bufrdeco/bufrdeco.h
+++ b/src/bufrdeco/bufrdeco.h
@@ -290,7 +290,7 @@
   \def BUFR_TABLEB_NAME_LENGTH
   \brief Max length (in chars) reserved for the unit string in table B
 */
-#define BUFR_TABLEB_UNIT_LENGTH (32)
+#define BUFR_TABLEB_UNIT_LENGTH (64)
 
 /*!
  * \def BUFR_CVAL_LENGTH


### PR DESCRIPTION
I have a segmentation fault (core dumped) when running bufrtotac on NOAA's data. Increasing BUFR_TABLEB_UNIT_LENGTH from 32 to 64 seems to fix the problem. (There is no specific reason to choose 64, except that it is greater than 32)