### PR TITLE
increase BUFR_TABLEB_NAME_LENGTH to 512 to prevent overflows

### DIFF
--- a/src/bufrdeco/bufrdeco.h
+++ b/src/bufrdeco/bufrdeco.h
@@ -314,7 +314,7 @@
   \def BUFR_TABLEB_NAME_LENGTH
   \brief Max length (in chars) reserved for a name of variable in table B
 */
-#define BUFR_TABLEB_NAME_LENGTH (128)
+#define BUFR_TABLEB_NAME_LENGTH (512)
 
 /*!
   \def BUFR_TABLEB_NAME_LENGTH


### PR DESCRIPTION
I still have some overflows with NOAA's data.
256 is not enough. 512 seems sufficient.