### PR TITLE
Fix handling of empty bulletins

### DIFF
--- a/src/apps/bufrnoaa.c
+++ b/src/apps/bufrnoaa.c
@@ -358,6 +358,20 @@ int main ( int argc, char *argv[] )
                   nerr++;
                   break;
                 }
+              // Has been detected some void and fakes bufr
+              if ( b[0] == '0' && // This is supossed to be the first '0' in the extension of next BUFR
+                   b[1] == HEADER_MARK &&
+                   b[2] == HEADER_MARK &&
+                   b[3] == HEADER_MARK &&
+                   b[4] == HEADER_MARK 
+                 )
+                {
+                  // Ooops. a fake bufr
+                  // it seems a new header has been found before 'BUFR'
+                  STAGE = 0;
+                  nerr++;
+                  break;
+                }
               if ( is_bufr ( &b[0] ) )
                 {
                   STAGE = 5;


### PR DESCRIPTION
Hello,

thank you for the useful tool.

We came across this example today which resulted in content of INRS07 RKSL 050900 being written to ISIC20_VGDC_050900.bufr which created issues in our downstream decoding.
```[...]
T"AXDO^L^AAYND^Q^OC^YF^Q<88> 7777****0000000025****
ISIC20 VGDC 050900^M^M
NIL=****0000107867****
INRS07 RKSL 050900^M^M
BUFR
^L?^AuÃ CÊÀ
[...]
```

In the code there is already a test included if a new header is present while processing until 7777 but this test was not included while checking for BUFR after the header was processed. This pull request adds this test also at this stage of processing. 

If you find it useful feel free to merge.

Best regards
Dennis Schulze
MeteoIQ GmbH